### PR TITLE
Pass CHANGE_JS_DEPS to integ-tests in dev stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,18 @@ pipeline {
                         // ],
                         [
                             $class: 'StringParameterValue',
+                            name: 'ton_client_js_commit',
+                            // value: "master"
+                            value: "0.24.0-rc"
+                        ],
+                        [
+                            $class: 'BooleanParameterValue',
+                            name: 'CHANGE_JS_DEPS',
+                            // value: false
+                            value: true
+                        ],
+                        [
+                            $class: 'StringParameterValue',
                             name: 'ton_client_web_js_branch',
                             value: "${GIT_BRANCH}"
                         ],


### PR DESCRIPTION
While develop in branch which linked with special `ton-client-js` branch currently also under development, just set` CHANGE_JS_DEPS` to `true` and` ton_client_js_commit` to <ton-client-js branch name> or specific commit on it, instead of default values ​​`false` and` master`.
Then `ton-client-js` dependency for current package will be overwritten during the tests, to be tested with right dependency.
NB: !!! Always check you reverted these parameters to its defaults (​​`false` and` master`) before merging to master !!!