### PR TITLE
Feature binary_version as env var

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -14,7 +14,7 @@ window.addEventListener('load', () => {
             servers: ['net.ton.dev']
         });
         debugLog(`Client creation time: ${(Date.now() - createStart)}`);
-        debugLog(`Client version: ${await client.config.getVersion()}`);
+        debugLog(`Client uses binary version: ${await client.config.getVersion()}`);
         debugLog(`Client connected to: ${await client.config.data.servers}`);
         const queryStart = Date.now();
         const accounts = await client.queries.accounts.query({}, 'id balance(format:DEC)', [{path:'balance', direction:'DESC'}], 10);

--- a/install.js
+++ b/install.js
@@ -2,9 +2,9 @@ const fs = require('fs');
 const path = require('path');
 const http = require('http');
 const zlib = require('zlib');
-const {version, binaries_version} = require('./package.json');
+const {version} = require('./package.json');
 
-const bv = (binaries_version || version).split('.')[0];
+const bv = process.env.TON_SDK_BIN_VERSION || (version).split('.')[0];
 
 const root = process.cwd();
 const binariesHost = 'sdkbinaries-ws.tonlabs.io';
@@ -16,7 +16,7 @@ function downloadAndGunzip(dest, url) {
         const request = http.get(url, response => {
             if (response.statusCode !== 200) {
                 reject({
-                    message: `Download failed with ${response.statusCode}: ${response.statusMessage}`,
+                    message: `Download from ${url} failed with ${response.statusCode}: ${response.statusMessage}`,
                 });
                 return;
             }
@@ -72,7 +72,7 @@ function downloadAndGunzip(dest, url) {
 async function dl(dst, src) {
     const dst_path = `${root}/${dst}`;
     const src_url = `http://${binariesHost}/${src}.gz`;
-    process.stdout.write(`Downloading ${dst} from ${src_url} to ${dst_path} ...`);
+    process.stdout.write(`Downloading from ${src_url} to ${dst_path} ...`);
     await downloadAndGunzip(dst_path, src_url);
     process.stdout.write('\n');
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "ton-client-web-js",
 	"version": "0.24.0",
-	"binaries_version": "0.23.1",
 	"description": "TON Client Library for Web",
 	"scripts": {
 		"install": "node install.js"


### PR DESCRIPTION
See in test logs while passing `TON_SDK_BIN_VERSION=0_23_101` (as env var):
- install:
```
...
[2020-05-29T14:43:27.159Z] #10 38.57 > ton-client-web-js@0.24.0 install /root/wasm-app/example/node_modules/ton-client-web-js
[2020-05-29T14:43:27.159Z] #10 38.57 > node install.js
[2020-05-29T14:43:27.159Z] #10 38.57 
[2020-05-29T14:43:27.410Z] #10 38.67 Downloading from http://sdkbinaries-ws.tonlabs.io/tonclient_0_23_101_wasm.gz to /root/wasm-app/tonclient.wasm ...
[2020-05-29T14:43:27.410Z] #10 38.85 Downloading from http://sdkbinaries-ws.tonlabs.io/tonclient_0_23_101_wasm_js.gz to /root/wasm-app/index.js ...
...
```
https://builder.tonlabs.io/jenkins/blue/organizations/jenkins/Integration%2Fintegration-tests/detail/sdk-bin-ver-4-wasm/9/pipeline/58#step-68-log-84

- run:
```
...
[2020-05-29T14:44:05.332Z] Client uses binary version: 0.23.101
...
```
https://builder.tonlabs.io/jenkins/blue/organizations/jenkins/Integration%2Fintegration-tests/detail/sdk-bin-ver-4-wasm/9/pipeline/80#step-126-log-12